### PR TITLE
Update Util.php

### DIFF
--- a/common/helpers/Util.php
+++ b/common/helpers/Util.php
@@ -177,7 +177,7 @@ class Util
      */
     public static function getThumbName($fullName, $width, $heith)
     {
-        $dotPosition = strrpos($fullName, '.');
+        $dotPosition = strrpos($fullName, '.',mb_strlen(Yii::getAlias('@frontend')));
         $thumbExt = "@" . $width . 'x' . $heith;
         if( $dotPosition === false ){
             $thumbFullName = $fullName . $thumbExt;


### PR DESCRIPTION
解决因项目目录带有`.`对`\common\helpers\Util::getThumbName`造成影响，导致open_basedir设置为项目目录的情况下，修改文章缩略图出错问题